### PR TITLE
ステップ11: タスク一覧を作成日時の順番で並び替えよう Issues/#11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  # Rspec
+  gem 'rspec-rails'
+  gem 'factory_bot_rails'
 end
 
 group :test do

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order("created_at DESC")
   end
 
   def new

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,9 +4,9 @@
 <table>
 <% @tasks.each do |task| %>
   <tr>
-    <td><%= task.title %></td>
+    <td class="task_title"><%= task.title %></td>
     <td><%= task.content %></td>
-    <td><%= link_to t('view.detail'), task_path(task.id) %></td>
+    <td><%= link_to t('view.detail'), task_path(task.id), class: 'submit' %></td>
     <td><%= link_to t('view.edit'), edit_task_path(task.id) %></td>
     <td><%= link_to t('view.delete'), task_path(task.id), method: :delete, data: { confirm: t('view.alert_delete') } %></td>
   </tr>

--- a/db/migrate/20190704045855_add_timestamps_to_tasks.rb
+++ b/db/migrate/20190704045855_add_timestamps_to_tasks.rb
@@ -1,0 +1,4 @@
+class AddTimestampsToTasks < ActiveRecord::Migration[5.2]
+  def change
+  end
+end

--- a/db/migrate/20190704045855_add_timestamps_to_tasks.rb
+++ b/db/migrate/20190704045855_add_timestamps_to_tasks.rb
@@ -1,4 +1,6 @@
 class AddTimestampsToTasks < ActiveRecord::Migration[5.2]
   def change
+    add_column :tasks, :created_at, :datetime
+    add_column :tasks, :updated_at, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_28_095403) do
+ActiveRecord::Schema.define(version: 2019_07_04_045855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,6 +18,8 @@ ActiveRecord::Schema.define(version: 2019_06_28_095403) do
   create_table "tasks", force: :cascade do |t|
     t.string "title"
     t.text "content"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,14 @@
+# FactoryBotを使用します
+FactoryBot.define do
+
+  factory :task do
+    title { 'タイトルaタイトルa' }
+    content { 'コンテンツaコンテンツaコンテンツa' }
+  end
+
+  factory :second_task, class: Task do
+    title { 'タイトルbタイトルb' }
+    content { 'コンテンツbコンテンツbコンテンツb' }
+  end
+
+end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -43,11 +43,19 @@ RSpec.feature "タスク管理機能", type: :feature do
   scenario "一覧ページから詳細ページへの遷移" do
     # background do の内容が先に実行される
     visit tasks_path
-    #save_and_open_page
-    click_link '詳細'
+    # save_and_open_page
+    # click_link '詳細'
+    all('tr')[0].click_link('詳細')
   end
 
   scenario "タスクが作成日時の降順に並んでいるかのテスト" do
+    # background do の内容が先に実行される
+    visit tasks_path
+    # save_and_open_page
+    # ページの要素
+    task = all('.task_title')
+    expect(task[0]).to have_content('タイトルbタイトルb')
+    expect(task[1]).to have_content('タイトルaタイトルa')
   end
 
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -1,19 +1,27 @@
 require 'rails_helper'
 
 RSpec.feature "タスク管理機能", type: :feature do
+  
+  background do
+    # あらかじめタスク一覧のテストで使用するためのタスクを二つ作成する
+    FactoryBot.create(:task)
+    FactoryBot.create(:second_task)
+    # Task.create!(title: 'タイトルa', content: 'コンテンツa')
+    # Task.create!(title: 'タイトルb', content: 'コンテンツb')
+  end
 
   scenario "タスク一覧のテスト" do
-    Task.create!(title: 'タイトルc', content: 'コンテンツc')
-    Task.create!(title: 'タイトルd', content: 'コンテンツd')
+    # background do の内容が先に実行される
   
     visit tasks_path
     # visit "/tasks"
     # visit root_path
 
+    # テスト処理を止めてviewページを表示ことができる
     # save_and_open_page
   
-    expect(page).to have_content 'コンテンツc'
-    expect(page).to have_content 'コンテンツd'
+    expect(page).to have_content 'コンテンツa'
+    expect(page).to have_content 'コンテンツb'
   end
 
   scenario "新規投稿テスト" do
@@ -33,9 +41,13 @@ RSpec.feature "タスク管理機能", type: :feature do
   end
 
   scenario "一覧ページから詳細ページへの遷移" do
-    Task.create!(title: 'タイトルa', content: 'コンテンツa')
+    # background do の内容が先に実行される
     visit tasks_path
     #save_and_open_page
     click_link '詳細'
   end
+
+  scenario "タスクが作成日時の降順に並んでいるかのテスト" do
+  end
+
 end


### PR DESCRIPTION
以下に対応しました。

>現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう
>並び替えがうまく行っていることをfeature specで書いてみましょう