### PR TITLE
ステップ14: 終了期限を追加しよう Issues/#14

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,11 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all.order("created_at DESC")
+    if params[:sort]
+      @tasks = Task.all.order("deadline DESC")
+    else
+      @tasks = Task.all.order("created_at DESC")
+    end
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -49,7 +49,7 @@ class TasksController < ApplicationController
   private
   
   def task_params
-    params.require(:task).permit(:title, :content)
+    params.require(:task).permit(:title, :content, :deadline)
   end
 
   def set_task

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,4 +2,5 @@ class Task < ApplicationRecord
   # 内容が空／同じものの重複
   validates :title, presence: true, uniqueness: true
   validates :title, length: { maximum: 101 }
+  validates :deadline, presence: true
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -18,6 +18,10 @@
     <%= form.label :'content', t('view.content') %>
     <%= form.text_field :content, id: 'content' %>
   </div>
+  <div class="task_title">
+    <%= form.label :'deadline', t('view.deadline') %>
+    <%= form.date_field :deadline, id: 'deadline' %>
+  </div>
   <div class="submit">
     <%= form.submit t('view.submit') %>
   </div>

--- a/app/views/tasks/confirm.html.erb
+++ b/app/views/tasks/confirm.html.erb
@@ -3,14 +3,17 @@
 <%= form_with(model: @task, url: tasks_path, local: true) do |form| %>
   <%= form.hidden_field :title %>
   <%= form.hidden_field :content %>
+  <%= form.hidden_field :deadline %>
 
   <p><%= t('view.title') %>：<%= @task.title %></p>
   <p><%= t('view.content') %>：<%= @task.content %></p>
+  <p><%= t('view.deadline') %>：<%= @task.deadline %></p>
   <%= form.submit  t('view.submit') %>
 <% end %>
 
 <%= form_with(model: @task, url: new_task_path, local: true, method: 'get') do |form| %>
   <%= form.hidden_field :title %>
   <%= form.hidden_field :content %>
+  <%= form.hidden_field :deadline %>
   <%= form.submit t('view.back'), name: 'back' %>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,6 +2,11 @@
 <p><%= notice %></p>
 
 <table>
+  <tr>
+    <td><%= t('view.title') %></td>
+    <td><%= t('view.content') %></td>
+    <td><%= t('view.deadline') %></td>
+  </tr>
 <% @tasks.each do |task| %>
   <tr>
     <td class="task_title"><%= task.title %></td>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -6,6 +6,7 @@
   <tr>
     <td class="task_title"><%= task.title %></td>
     <td><%= task.content %></td>
+    <td><%= task.deadline %></td>
     <td><%= link_to t('view.detail'), task_path(task.id), class: 'submit' %></td>
     <td><%= link_to t('view.edit'), edit_task_path(task.id) %></td>
     <td><%= link_to t('view.delete'), task_path(task.id), method: :delete, data: { confirm: t('view.alert_delete') } %></td>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,6 +1,11 @@
 <h1><%= t('view.title_h1_index') %></h1>
 <p><%= notice %></p>
 
+<div class="btn_sort">
+  <p><%= link_to t('view.sort_deadline'), tasks_path(sort: true) %></p>
+  <p><%= link_to t('view.sort_created_at'), tasks_path %></p>
+</div>
+
 <table>
   <tr>
     <td><%= t('view.title') %></td>
@@ -11,7 +16,7 @@
   <tr>
     <td class="task_title"><%= task.title %></td>
     <td><%= task.content %></td>
-    <td><%= task.deadline %></td>
+    <td class="sort_test_capybara"><%= task.deadline %></td>
     <td><%= link_to t('view.detail'), task_path(task.id), class: 'submit' %></td>
     <td><%= link_to t('view.edit'), edit_task_path(task.id) %></td>
     <td><%= link_to t('view.delete'), task_path(task.id), method: :delete, data: { confirm: t('view.alert_delete') } %></td>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -222,3 +222,5 @@ ja:
     title_h1_show: ブログ詳細画面
     title_h1_confirm: 以下の内容で送信する
     title_h1_edit: 編集する
+    sort_deadline: 終了期限順に表示
+    sort_created_at: 作成順に表示

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -208,6 +208,7 @@ ja:
   view:
     title: タイトル
     content: タスク内容
+    deadline: 終了期日
     submit: 投稿する
     new: 新規作成
     back: 一覧へ戻る

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -7,6 +7,7 @@ ja:
       task:
         title: "タイトル"
         content: "タスク内容"
+        deadline: "終了期日"
       # user:
       #   title: "タイトル"
       #   name: "名前"

--- a/db/migrate/20190709090646_add_deadline_to_tasks.rb
+++ b/db/migrate/20190709090646_add_deadline_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddDeadlineToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :deadline, :datetime
+  end
+end

--- a/db/migrate/20190709101755_add_notnull_to_deadline_on_tasks.rb
+++ b/db/migrate/20190709101755_add_notnull_to_deadline_on_tasks.rb
@@ -1,0 +1,5 @@
+class AddNotnullToDeadlineOnTasks < ActiveRecord::Migration[5.2]
+  def change
+    change_column :tasks, :deadline, :datetime, default: ' ', null: false
+  end
+end

--- a/db/migrate/20190709114145_change_datatype_deadline_on_tasks.rb
+++ b/db/migrate/20190709114145_change_datatype_deadline_on_tasks.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypeDeadlineOnTasks < ActiveRecord::Migration[5.2]
+  def change
+    change_column :tasks, :deadline, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_08_085007) do
+ActiveRecord::Schema.define(version: 2019_07_09_090646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2019_07_08_085007) do
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deadline"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_09_101755) do
+ActiveRecord::Schema.define(version: 2019_07_09_114145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2019_07_09_101755) do
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "deadline", null: false
+    t.date "deadline", null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_09_090646) do
+ActiveRecord::Schema.define(version: 2019_07_09_101755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2019_07_09_090646) do
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "deadline"
+    t.datetime "deadline", null: false
   end
 
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -4,11 +4,19 @@ FactoryBot.define do
   factory :task do
     title { 'タイトルaタイトルa' }
     content { 'コンテンツaコンテンツaコンテンツa' }
+    deadline { '2019-07-27' }
   end
 
   factory :second_task, class: Task do
     title { 'タイトルbタイトルb' }
     content { 'コンテンツbコンテンツbコンテンツb' }
+    deadline { '2019-07-30' }
+  end
+
+  factory :third_task, class: Task do
+    title { 'タイトルcタイトルc' }
+    content { 'コンテンツcコンテンツcコンテンツc' }
+    deadline { '2019-08-08' }
   end
 
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -6,13 +6,13 @@ RSpec.feature "タスク管理機能", type: :feature do
     # あらかじめタスク一覧のテストで使用するためのタスクを二つ作成する
     FactoryBot.create(:task)
     FactoryBot.create(:second_task)
+    FactoryBot.create(:third_task)
     # Task.create!(title: 'タイトルa', content: 'コンテンツa')
     # Task.create!(title: 'タイトルb', content: 'コンテンツb')
   end
 
   scenario "タスク一覧のテスト" do
     # background do の内容が先に実行される
-  
     visit tasks_path
     # visit "/tasks"
     # visit root_path
@@ -31,7 +31,8 @@ RSpec.feature "タスク管理機能", type: :feature do
     # 「タスク名」というラベル名の入力欄と、「タスク詳細」というラベル名の入力欄に
     # タスクのタイトルと内容をそれぞれfill_in（入力）する
     fill_in 'title', with: 'これはタイトルのテスト'
-    fill_in 'content', with: 'これはコンテンツ内容テスト' 
+    fill_in 'content', with: 'これはコンテンツ内容テスト'
+    fill_in 'deadline', with: '2019-07-27'
 
     # 4.「登録する」というvalue（表記文字）のあるボタンをclick_onする（クリックする）する処理を書く
     click_on '投稿する'
@@ -45,7 +46,7 @@ RSpec.feature "タスク管理機能", type: :feature do
     visit tasks_path
     # save_and_open_page
     # click_link '詳細'
-    all('tr')[0].click_link('詳細')
+    all('tr')[1].click_link('詳細')
   end
 
   scenario "タスクが作成日時の降順に並んでいるかのテスト" do
@@ -54,8 +55,20 @@ RSpec.feature "タスク管理機能", type: :feature do
     # save_and_open_page
     # ページの要素
     task = all('.task_title')
-    expect(task[0]).to have_content('タイトルbタイトルb')
-    expect(task[1]).to have_content('タイトルaタイトルa')
+    expect(task[0]).to have_content('タイトルcタイトルc')
+    expect(task[1]).to have_content('タイトルbタイトルb')
+    expect(task[2]).to have_content('タイトルaタイトルa')
+  end
+
+  scenario "タスクが終了期限の降順に並んでいるかのテスト" do
+    # background do の内容が先に実行される
+    visit tasks_path
+    click_on '終了期限順に表示'
+    # save_and_open_page
+    task = all('.sort_test_capybara')
+    expect(task[0]).to have_content('2019-08-08'.to_date)
+    expect(task[1]).to have_content('2019-07-30'.to_date)
+    expect(task[2]).to have_content('2019-07-27'.to_date)
   end
 
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -14,10 +14,12 @@ describe Task do
   it "is invalid with a duplicate title" do
     Task.create(
       title: 'タイトルA',
-      content: 'コンテンツAコンテンツAコンテンツA')
+      content: 'コンテンツAコンテンツAコンテンツA',
+      deadline: '2019-07-18')
     task =  Task.new(
       title: 'タイトルA',
-      content: 'コンテンツAコンテンツAコンテンツA')
+      content: 'コンテンツAコンテンツAコンテンツA',
+      deadline: '2019-07-27')
     task.valid?
     expect(task.errors[:title]).to include("はすでに存在します")
   end


### PR DESCRIPTION
以下タスクに対応いたしました。
どうぞご確認をお願いいたします。

タスクに対して、終了期限を登録できるようにしてみましょう

一覧画面で、終了期限でソートできるようにしましょう
（「終了期限でソートする」というボタン（リンク）を作成し、そのボタンを押すと、
終了期限の降順に並び替えられたタスク一覧ページが出現するようにしましょう！）

今回追加した機能のテストをfeature specで追記しましょう